### PR TITLE
Add comprehensive SEO and social media metadata to site head

### DIFF
--- a/content/posts/20190909-data-exposure/index.md
+++ b/content/posts/20190909-data-exposure/index.md
@@ -21,7 +21,7 @@ categories: ["article"]
 
 The most frustrating security incidents I've dealt with as an engineering leader weren't caused by sophisticated attacks or zero-day vulnerabilities. They were caused by well-intentioned team members who accidentally exposed sensitive data through everyday tools and processes. A developer pasting API keys into a public Slack channel. A support engineer sharing database credentials through an unsecured text-sharing service. A product manager including real customer data in a publicly accessible report.
 
-These incidents reveal a fundamental truth about data protection: it's not primarily a technical problem—it's an organizational one. The security of our applications depends as much on how our teams handle sensitive data in their daily workflows as it does on our encryption algorithms or access controls.
+These incidents reveal a fundamental truth about data protection: it's not primarily a technical problem—it's an organizational one. The security of our applications depends as much on how our teams handle sensitive data in their daily workflows as it does on our encryption algorithms or access controls. (The flip side of culture is the architecture that encodes it—see [how engineering leaders build security culture through architecture decisions](/posts/how-engineering-leaders-build-security-culture-through-architecture-decisions/).)
 
 The challenge for engineering leaders is that traditional security approaches focus on technical controls while overlooking the human systems that determine how data actually flows through our organizations. When we treat data protection as purely a technical problem, we create a gap between our security policies and the reality of how our teams work.
 

--- a/content/posts/20190930-secure-web-app/index.md
+++ b/content/posts/20190930-secure-web-app/index.md
@@ -19,7 +19,7 @@ Leading engineering teams means constantly balancing several goals: speed to mar
 
 The "we can do security later" mindset creates what I call security debt—technical decisions that make it exponentially harder to secure applications as they scale. Unlike other forms of technical debt, security debt compounds in immediately dangerous ways. A rushed architectural decision made to meet a deadline can become a persistent vulnerability that affects every feature built on top of it.
 
-As engineering leaders, we have a unique opportunity to shape how our teams think about security. The architectural decisions we make and the frameworks we establish don't just affect our current codebase—they define the security culture that will carry our teams through future challenges.
+As engineering leaders, we have a unique opportunity to shape how our teams think about security. The architectural decisions we make and the frameworks we establish don't just affect our current codebase—they define the security culture that will carry our teams through future challenges. That culture takes hold when your whole team learns to [think like a hacker](/posts/how-to-think-like-a-hacker-and-why-your-team-should-too/) and a [data protection mindset](/posts/building-data-protection-culture-why-engineering-leaders-must-address-the-human-side-of-security/) becomes second nature.
 
 > I've found that the most effective approach isn't to mandate security practices after the fact, but to build security thinking into the fundamental architectural decisions that guide daily development work.
 

--- a/content/posts/20200225-breaking-bottlenecks/index.md
+++ b/content/posts/20200225-breaking-bottlenecks/index.md
@@ -116,7 +116,7 @@ The decision matrix looked like this:
 - ****Maintainability****: We needed something contributors could debug and extend
 - ****Long-term scalability****: The solution needed to handle growing content without constant optimization
 
-I chose to prototype the link checker in both languages. I built a multithreaded Python version that I dubbed [Hydra](https://github.com/victoriadrake/hydra-link-checker), and a Go version that took advantage of goroutines. This gave us concrete data to inform the decision rather than relying on assumptions. This approach—building multiple solutions to validate architectural choices—is something I've found invaluable for critical infrastructure decisions.
+I chose to prototype the link checker in both languages. I built a multithreaded Python version that I dubbed [Hydra](https://github.com/victoriadrake/hydra-link-checker), and a Go version that took advantage of goroutines. This gave us concrete data to inform the decision rather than relying on assumptions. This approach—building multiple solutions to validate architectural choices—is something I've found invaluable for critical infrastructure decisions. (For the technical deep dive on how Hydra's multithreading actually achieved its speedup, see [17 Minutes to 16 Seconds](/posts/17-minutes-to-16-seconds-a-60x-performance-improvement-from-python/).)
 
 ## Designing Solutions That Scale With Your Team
 

--- a/content/posts/20200228-multithread-python/index.md
+++ b/content/posts/20200228-multithread-python/index.md
@@ -160,6 +160,6 @@ Most importantly, it means recognizing that performance optimization is a techni
 
 ## The Real Lesson
 
-Hydra’s performance gains from 17 minutes to 16 seconds teaches a lesson that applies far beyond Python: measure first, optimize second, and always focus on the constraint that’s actually limiting your system. Whether you’re debugging performance bottlenecks or organizational inefficiencies, the biggest wins come from addressing the right problem rather than optimizing the wrong one exceptionally well.
+Hydra’s performance gains from 17 minutes to 16 seconds teaches a lesson that applies far beyond Python: measure first, optimize second, and always focus on the constraint that’s actually limiting your system. Whether you’re debugging performance bottlenecks or organizational inefficiencies, the biggest wins come from addressing the right problem rather than optimizing the wrong one exceptionally well. For the leadership side of this story—how breaking this bottleneck reshaped an entire team's workflow—see [From 17 Minutes to 8 Seconds](/posts/from-17-minutes-to-8-seconds-strategic-performance-optimization-for-engineering-teams/).
 
 The next time your team debates whether to rewrite everything in Go for performance, remember Hydra's 60x improvement using standard Python libraries. Sometimes the most effective optimization is the one you can implement this week rather than the solution you'll build next quarter… or the quarter after that.

--- a/themes/bluf/layouts/partials/head.html
+++ b/themes/bluf/layouts/partials/head.html
@@ -3,6 +3,54 @@
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
 <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.description }}{{ end }}">
 
+{{/* Social & SEO metadata */}}
+{{- $title := cond .IsHome .Site.Title (printf "%s | %s" .Title .Site.Title) -}}
+{{- $desc := cond (ne .Description "") .Description .Site.Params.description -}}
+{{- $ogImage := .Site.Params.socialImage -}}
+{{- with .Params.image -}}
+    {{- with ($.Resources.GetMatch .) -}}
+        {{- $ogImage = .Permalink -}}
+    {{- else -}}
+        {{- $ogImage = . -}}
+    {{- end -}}
+{{- end -}}
+{{- $ogImage = $ogImage | absURL -}}
+
+<link rel="canonical" href="{{ .Permalink }}">
+
+<!-- Open Graph -->
+<meta property="og:title" content="{{ $title }}">
+<meta property="og:description" content="{{ $desc }}">
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
+<meta property="og:site_name" content="{{ .Site.Title }}">
+<meta property="og:image" content="{{ $ogImage }}">
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary_large_image">
+{{ with .Site.Params.twitteruser }}<meta name="twitter:site" content="@{{ . }}">{{ end }}
+<meta name="twitter:title" content="{{ $title }}">
+<meta name="twitter:description" content="{{ $desc }}">
+<meta name="twitter:image" content="{{ $ogImage }}">
+
+{{ if and .IsPage (eq .Section "posts") }}
+<!-- JSON-LD BlogPosting -->
+{{- $schema := dict
+    "@context" "https://schema.org"
+    "@type" "BlogPosting"
+    "headline" .Title
+    "description" $desc
+    "datePublished" (.Date.Format "2006-01-02T15:04:05Z07:00")
+    "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+    "image" $ogImage
+    "url" .Permalink
+    "mainEntityOfPage" .Permalink
+    "author" (dict "@type" "Person" "name" .Site.Params.author.name "url" .Site.Params.author.domain)
+    "publisher" (dict "@type" "Person" "name" .Site.Params.author.name)
+-}}
+<script type="application/ld+json">{{ $schema | jsonify | safeJS }}</script>
+{{ end }}
+
 <!-- Theme color for Safari and mobile browsers -->
 <meta name="theme-color" content="#000000">
 <meta name="apple-mobile-web-app-status-bar-style" content="black">


### PR DESCRIPTION
## Summary
This PR enhances the site's SEO and social media presence by adding comprehensive metadata to the document head, including Open Graph tags, Twitter Card support, canonical links, and JSON-LD structured data for blog posts.

## Key Changes

- **Social & SEO Metadata**: Added a new metadata section in `themes/bluf/layouts/partials/head.html` that includes:
  - Canonical link tags for proper URL attribution
  - Open Graph meta tags (title, description, URL, type, site name, image)
  - Twitter Card meta tags with support for custom Twitter handle
  - JSON-LD BlogPosting schema for blog posts with publication dates, author information, and structured data

- **Image Handling**: Implemented intelligent social image resolution that:
  - Checks for page-specific images in front matter
  - Falls back to site-wide default social image
  - Properly resolves relative paths to absolute URLs

- **Content Updates**: Added cross-linking between related blog posts to improve internal navigation and SEO:
  - `20190909-data-exposure/index.md`: Added link to architecture-focused security culture post
  - `20190930-secure-web-app/index.md`: Added links to hacker mindset and data protection posts
  - `20200225-breaking-bottlenecks/index.md`: Added link to technical deep dive on Hydra performance
  - `20200228-multithread-python/index.md`: Added link to leadership perspective on the same optimization

## Implementation Details

- Uses Hugo's conditional logic to set appropriate metadata based on page type (home vs. content pages)
- JSON-LD schema only renders for blog posts in the "posts" section
- Image metadata properly handles both page resources and external URLs
- All metadata variables are pre-computed to avoid repetition and ensure consistency across different meta tag types

https://claude.ai/code/session_014Aq6A1Q6AVYbUb1c7SnUnH